### PR TITLE
Refactoring webpack example

### DIFF
--- a/examples/webpack/tsconfig.json
+++ b/examples/webpack/tsconfig.json
@@ -1,83 +1,30 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    //     "lib": ["dom"],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
+    
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
+    "strict": true /* Enable all strict type-checking options. */,
+   
     /* Module Resolution Options */
-         "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    //    "baseUrl": ".",
-    //    "paths": {
-    //      "*": ["src/*"]
-    //    },
-    "baseUrl": "src",                       /* Base directory to resolve non-absolute module names. */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "src" /* Base directory to resolve non-absolute module names. */,
     "paths": {
-//      "*.html": "node_modules/simple-boot-front/types/index.d.ts"
       "@src/*": ["../src/*"]
-    },                          /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-//    "include": ["src/*","src/**/*"],
-//    "include": ["simple-boot-front/type"],
-     "typeRoots": ["node_modules/@types"],                       /* List of folders to include type definitions from. */
-//     "types": ["simple-boot-front"],                           /* Type declaration files to be included in compilation. */
-//     "types": ["simple-boot-front/types/index.d.ts"],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
+    }, /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "typeRoots": ["node_modules/@types"] /* List of folders to include type definitions from. */,
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    
     /* Experimental Options */
-     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-     "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true,
     /* Disallow inconsistently-cased references to the same file. */
-    "lib": [
-      "dom",
-      "es5",
-      "scripthost",
-      "es2015.proxy"
-    ]
+    "lib": ["dom", "es5", "scripthost", "es2015.proxy"]
   }
 }

--- a/examples/webpack/tsconfig.json
+++ b/examples/webpack/tsconfig.json
@@ -18,6 +18,8 @@
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     
+    "types": ["node"],
+
     /* Experimental Options */
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,140 +1,77 @@
-const path = require('path')
-const HtmlWebPackPlugin = require('html-webpack-plugin')
-const { CleanWebpackPlugin } = require('clean-webpack-plugin')
-// const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
-// const tsConfigPath = path.resolve(__dirname, "tsconfig")
-
-// var HtmlWebpackPlugin = require('html-webpack-plugin'); // https://github.com/jantimon/html-webpack-plugin
-// var ExtractTextPlugin = require('extract-text-webpack-plugin'); // https://webpack.js.org/plugins/extract-text-webpack-plugin/
+const path = require('path');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-    entry: './src/index.ts',
-    devtool: 'inline-source-map',
-    mode: 'development',
-    watch: true,
-    // resolve: {
-    //     alias: {
-    //         handlebars: 'handlebars/dist/handlebars.min.js'
-    //     }
-    // },
-    // resolve: {
-    //     // Add `.ts` and `.tsx` as a resolvable extension.
-    //     extensions: [".ts", ".tsx", ".js"],
-    //     plugins: [new TsconfigPathsPlugin({ configFile: './tsconfig.json' })]
-    // },
-    module: {
-        rules: [
-            {
-                test: /\.tsx?$/,
-                use: 'ts-loader',
-                exclude: /node_modules/
+  entry: './src/index.ts',
+  devtool: 'inline-source-map',
+  mode: 'development',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.script\.js$/,
+        use: [
+          {
+            loader: 'script-loader',
+            options: {
+              sourceMap: true,
             },
-            {
-                test: /\.script\.js$/,
-                use: [
-                    {
-                        loader: 'script-loader',
-                        options: {
-                            sourceMap: true
-                        }
-                    }
-                ]
-            },
-            {
-                test: /\.(txt|min)$/i,
-                use: 'raw-loader'
-            },
-            {
-                test: /\.html$/i,
-                loader: 'html-loader'
-                // options: {
-                //     attributes: {
-                //         list: [
-                //             { tag: 'img', attribute: 'src', type: 'src' },
-                //             { tag: 'link', attribute: 'href', type: 'src' },
-                //             // { tag: 'a', attribute: 'href', type: 'src' } <--- throws error when included
-                //         ]
-                //     }
-                // }
-                // ,
-                // options: {
-                //     minimize: true
-                // }
-            },
-            // {
-            //     test: /\.css$/,
-            //     use: [
-            //         // {
-            //         //     loader: 'style-loader'
-            //         // },
-            //         {
-            //             loader: 'css-loader'
-            //         }
-            //         // "handlebars-loader", // handlebars loader expects raw resource string
-            //         // 'extract-loader',
-            //         // 'style-loader',
-            //         // 'css-loader'
-            //     ]
-            // },
-            // {
-            //     test: /\.(png|svg|jpe?g|gif)$/,
-            //     use: [
-            //         {
-            //             loader: 'file-loader',
-            //             options: {
-            //                 esModule: false
-            //             }
-            //         }
-            //     ]
-            // }
-            {
-                test: /\.hbs$/i,
-                use: [
-
-                    {
-                        loader: 'handlebars-loader'
-                    },
-                    // {
-                    //     loader: 'extract-loader'
-                    // },
-                    {
-                        loader: 'html-loader'
-
-                    }
-                    // "extract-loader",
-                ]
-            }
-        ]
-    },
-    plugins: [
-        new CleanWebpackPlugin(),
-        new HtmlWebPackPlugin({
-            template: './src/index.html', // public/index.html 파일을 읽는다.
-            filename: 'index.html' // output으로 출력할 파일은 index.html 이다.
-        })
+          },
+        ],
+      },
+      {
+        test: /\.(txt|min)$/i,
+        use: 'raw-loader',
+      },
+      {
+        test: /\.html$/i,
+        loader: 'html-loader',
+      },
+      {
+        test: /\.hbs$/i,
+        use: [
+          {
+            loader: 'handlebars-loader',
+          },
+          {
+            loader: 'html-loader',
+          },
+        ],
+      },
     ],
-    resolve: {
-        alias: {
-            handlebars: __dirname + '/node_modules/handlebars/dist/handlebars.min.js',
-            fs: false,
-            '@src': path.resolve(__dirname, 'src')
-        },
-        extensions: ['.tsx', '.ts', '.js']
-        // extensions: ['.tsx', '.ts', '.js', 'webpack.js', '.web.js', '.html'],
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new HtmlWebPackPlugin({
+      template: './src/index.html', // public/index.html 파일을 읽는다.
+      filename: 'index.html', // output으로 출력할 파일은 index.html 이다.
+    }),
+  ],
+  resolve: {
+    alias: {
+      handlebars: __dirname + '/node_modules/handlebars/dist/handlebars.min.js',
+      fs: false,
+      '@src': path.resolve(__dirname, 'src'),
     },
-    output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'dist')
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  devServer: {
+    inline: true,
+    hot: true,
+    contentBase: __dirname + '/dist/',
+    host: 'localhost',
+    port: 5500,
+    proxy: {
+      '/': 'http://localhost:8080', // 프록시
     },
-    devServer: {
-        inline: true,
-        hot: true,
-        contentBase: __dirname + '/dist/',
-        host: 'localhost',
-        port: 5500,
-        proxy: {
-            '/': 'http://localhost:8080' // 프록시
-        }
-        // contentBase: './dist'
-    }
-}
+  },
+};


### PR DESCRIPTION
Hi.

I Remove unnecessary comments and properties in `webpack.config.js` and `tsconfig.json`.

**`webpack.config.js`**
- remove "watch" property to remove this warning when I run `webpack serve`:
```
[webpack-cli] No need to use the 'serve' command together with '{ watch: true }' configuration, it does not make sense.
```

seeing dependencies in `package.json`,
comparing my own [webpack example test branch](https://github.com/geoseong/simple-boot-front/tree/example-webpack),
I think some of packages are not used in here.

can you explain where those are used in somewhere? If some packages is not used actually, I'll push another commit to remove this.
- supertest
- tsconfig-paths-webpack-plugin
- handlebars-loader
- reflect-metadata
- rollup
- handlebars-webpack-plugin
- html-webpack-plugin
- clean-webpack-plugin

Thanks